### PR TITLE
chore(flake): adopt mynixos 0.11.1 (vogix 0.8.0) + tpm-suppression + dram-rgb

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -73,26 +73,33 @@
         "devenv": [
           "mynixos",
           "vogix",
-          "crate2nix"
+          "devenv"
         ],
         "flake-compat": [
           "mynixos",
           "vogix",
-          "crate2nix"
+          "devenv",
+          "flake-compat"
         ],
-        "git-hooks": "git-hooks_2",
+        "git-hooks": [
+          "mynixos",
+          "vogix",
+          "devenv",
+          "git-hooks"
+        ],
         "nixpkgs": [
           "mynixos",
           "vogix",
+          "devenv",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1767714506,
-        "narHash": "sha256-WaTs0t1CxhgxbIuvQ97OFhDTVUGd1HA+KzLZUZBhe0s=",
+        "lastModified": 1777487137,
+        "narHash": "sha256-TuvKVBX60mqyMT6OB5JqVEh1YIWtFMR/igLCaCdC9tw=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "894c649f0daaa38bbcfb21de64be47dfa7cd0ec9",
+        "rev": "a66a440c321d35f7193472c317f42a55ccd1cb93",
         "type": "github"
       },
       "original": {
@@ -140,61 +147,33 @@
       }
     },
     "crate2nix": {
-      "inputs": {
-        "cachix": "cachix",
-        "devshell": "devshell",
-        "flake-compat": "flake-compat_2",
-        "flake-parts": "flake-parts_2",
-        "nix-test-runner": "nix-test-runner",
-        "nixpkgs": [
-          "mynixos",
-          "vogix",
-          "nixpkgs"
-        ],
-        "pre-commit-hooks": "pre-commit-hooks"
-      },
+      "flake": false,
       "locked": {
-        "lastModified": 1773799810,
-        "narHash": "sha256-0VyaHRFWoAbkNFvG892c5nXKyLnOhyiY/LVzOWX9dcc=",
-        "owner": "i-am-logger",
+        "lastModified": 1772186516,
+        "narHash": "sha256-8s28pzmQ6TOIUzznwFibtW1CMieMUl1rYJIxoQYor58=",
+        "owner": "rossng",
         "repo": "crate2nix",
-        "rev": "49d369e525db13646a790b53f8ff870778499293",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
         "type": "github"
       },
       "original": {
-        "owner": "i-am-logger",
-        "ref": "fix/remove-crate2nix-stable-input",
+        "owner": "rossng",
         "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
         "type": "github"
       }
     },
     "devenv": {
       "inputs": {
-        "cachix": [
-          "mynixos",
-          "vogix",
-          "crate2nix",
-          "cachix"
-        ],
-        "crate2nix": [
-          "mynixos",
-          "vogix",
-          "crate2nix"
-        ],
-        "flake-compat": [
-          "mynixos",
-          "vogix",
-          "crate2nix",
-          "flake-compat"
-        ],
-        "flake-parts": [
-          "mynixos",
-          "vogix",
-          "crate2nix",
-          "flake-parts"
-        ],
+        "cachix": "cachix",
+        "crate2nix": "crate2nix",
+        "flake-compat": "flake-compat_3",
+        "flake-parts": "flake-parts_2",
         "ghostty": "ghostty",
-        "git-hooks": "git-hooks_3",
+        "git-hooks": [
+          "mynixos",
+          "git-hooks"
+        ],
         "nix": "nix",
         "nixd": "nixd",
         "nixpkgs": [
@@ -209,39 +188,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1781195293,
-        "narHash": "sha256-C9OFghpvf3RzK2rGsZjjNNrTrHgFOecEkpDhFnU4QGs=",
+        "lastModified": 1781627264,
+        "narHash": "sha256-TPj5d5MUyvuQZjsfDAAoYJ0SB+tNNNBrdCpD8XL0WeU=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "5f5109c83854577191634f7b86fc6e0c8fd44964",
+        "rev": "0fe5629a2955141c336b95e384e2c793c01214fb",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "devenv",
-        "type": "github"
-      }
-    },
-    "devshell": {
-      "inputs": {
-        "nixpkgs": [
-          "mynixos",
-          "vogix",
-          "crate2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1768818222,
-        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
         "type": "github"
       }
     },
@@ -299,17 +255,35 @@
       }
     },
     "flake-compat_2": {
+      "flake": false,
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
-        "revCount": 69,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
       }
     },
     "flake-parts": {
@@ -339,16 +313,16 @@
         "nixpkgs-lib": [
           "mynixos",
           "vogix",
-          "crate2nix",
+          "devenv",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -430,74 +404,6 @@
         "type": "github"
       }
     },
-    "git-hooks_2": {
-      "inputs": {
-        "flake-compat": [
-          "mynixos",
-          "vogix",
-          "crate2nix",
-          "cachix",
-          "flake-compat"
-        ],
-        "gitignore": "gitignore_2",
-        "nixpkgs": [
-          "mynixos",
-          "vogix",
-          "crate2nix",
-          "cachix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1765404074,
-        "narHash": "sha256-+ZDU2d+vzWkEJiqprvV5PR26DVFN2vgddwG5SnPZcUM=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "2d6f58930fbcd82f6f9fd59fb6d13e37684ca529",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "git-hooks_3": {
-      "inputs": {
-        "flake-compat": [
-          "mynixos",
-          "vogix",
-          "devenv",
-          "flake-compat"
-        ],
-        "gitignore": [
-          "mynixos",
-          "vogix",
-          "crate2nix",
-          "pre-commit-hooks",
-          "gitignore"
-        ],
-        "nixpkgs": [
-          "mynixos",
-          "vogix",
-          "devenv",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -524,34 +430,8 @@
       "inputs": {
         "nixpkgs": [
           "mynixos",
-          "vogix",
-          "crate2nix",
-          "cachix",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_3": {
-      "inputs": {
-        "nixpkgs": [
-          "mynixos",
-          "vogix",
-          "crate2nix",
-          "pre-commit-hooks",
+          "lanzaboote",
+          "pre-commit",
           "nixpkgs"
         ]
       },
@@ -594,38 +474,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1781259653,
-        "narHash": "sha256-a1jSppP24tEUSxmVrX1Xi6spCOX3DPdqkF2pGf9MoAQ=",
+        "lastModified": 1781297513,
+        "narHash": "sha256-yjMBNCcWi4zCUqUjrgp9VxIys+MAAfqH1wyENNn0h7w=",
         "owner": "i-am-logger",
         "repo": "home-manager",
-        "rev": "e8215caddebd792188b9c5045abb92d5802e1d6e",
+        "rev": "ee91e5e635834893c5dd5bab70d16487f895a164",
         "type": "github"
       },
       "original": {
         "owner": "i-am-logger",
         "ref": "feature/webapps-module",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "home-manager_2": {
-      "inputs": {
-        "nixpkgs": [
-          "mynixos",
-          "vogix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781189114,
-        "narHash": "sha256-5inaamLgUMWy+MOBE9ChF9QAF1o/74LFuHkI0W/9rqc=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "486595d2cf49cfcd649b58a284fa11ac0e34da22",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
         "repo": "home-manager",
         "type": "github"
       }
@@ -703,11 +561,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1781181476,
-        "narHash": "sha256-4JLkQvN7/f77TyxXXtoEuUfovMqMLOgWpBaLMNX1dns=",
+        "lastModified": 1781649287,
+        "narHash": "sha256-ycG9a7svaV/zF9G03waY7BqUcNQn2HODMN/lXy3C7Zc=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "0403b4b7e8b2612657f0053a4c315e6c43eee9e6",
+        "rev": "001e560fffc8f0235e9db20ebeb4ccde0ade1caf",
         "type": "github"
       },
       "original": {
@@ -749,11 +607,11 @@
         "vogix": "vogix"
       },
       "locked": {
-        "lastModified": 1781292488,
-        "narHash": "sha256-VZk5mENGHQNdwi0ebou8GR1MdBFwtL8UEoBM8twTOTM=",
+        "lastModified": 1781723903,
+        "narHash": "sha256-cy14pQ07T753byHHR8ryvEkxb9BXoL9EacXmOcQa4uY=",
         "ref": "refs/heads/master",
-        "rev": "5a51f3ee6e2753bd998613a535b15c1c589333bb",
-        "revCount": 268,
+        "rev": "a7258032e9a08655f1258027cc72dffaec103388",
+        "revCount": 274,
         "type": "git",
         "url": "file:///home/logger/Code/github/logger/mynixos"
       },
@@ -814,22 +672,6 @@
         "type": "github"
       }
     },
-    "nix-test-runner": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1588761593,
-        "narHash": "sha256-FKJykltAN/g3eIceJl4SfDnnyuH2jHImhMrXS2KvGIs=",
-        "owner": "stoeffel",
-        "repo": "nix-test-runner",
-        "rev": "c45d45b11ecef3eb9d834c3b6304c05c49b06ca2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "stoeffel",
-        "repo": "nix-test-runner",
-        "type": "github"
-      }
-    },
     "nixd": {
       "inputs": {
         "flake-parts": [
@@ -877,31 +719,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -935,19 +761,8 @@
     },
     "pre-commit": {
       "inputs": {
-        "flake-compat": [
-          "mynixos",
-          "vogix",
-          "crate2nix",
-          "flake-compat"
-        ],
-        "gitignore": [
-          "mynixos",
-          "vogix",
-          "crate2nix",
-          "pre-commit-hooks",
-          "gitignore"
-        ],
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore_2",
         "nixpkgs": [
           "mynixos",
           "nixpkgs"
@@ -959,36 +774,6 @@
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
         "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": [
-          "mynixos",
-          "vogix",
-          "crate2nix",
-          "flake-compat"
-        ],
-        "gitignore": "gitignore_3",
-        "nixpkgs": [
-          "mynixos",
-          "vogix",
-          "crate2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769069492,
-        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
         "type": "github"
       },
       "original": {
@@ -1013,33 +798,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780802404,
-        "narHash": "sha256-bGtIUeLb0yChX4h6hB40OOCwcYhcpQZHXSDvZGdWgeM=",
+        "lastModified": 1781407245,
+        "narHash": "sha256-VzJq4MmD0uyNDAceudSe1hHqcQMe9Tau0U4S+5iRGh0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8e596a8430f2ce54d55c742198187d6945a5501e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_2": {
-      "inputs": {
-        "nixpkgs": [
-          "mynixos",
-          "vogix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781147846,
-        "narHash": "sha256-hBdiQYd40xRtBWBiXHUxuQYWmJBiK19YO1FiYgrmEo0=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "107c334f141854f563f8adf1db781dc453d92639",
+        "rev": "d5f483210eb016d66102eef22baa128b3b3233fc",
         "type": "github"
       },
       "original": {
@@ -1273,38 +1036,47 @@
     },
     "vogix": {
       "inputs": {
-        "crate2nix": "crate2nix",
         "devenv": "devenv",
-        "home-manager": "home-manager_2",
+        "home-manager": [
+          "mynixos",
+          "home-manager"
+        ],
         "iterm2-schemes": "iterm2-schemes",
         "liquidctl-src": "liquidctl-src",
-        "nixpkgs": "nixpkgs_2",
-        "rust-overlay": "rust-overlay_2",
+        "nixpkgs": [
+          "mynixos",
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "mynixos",
+          "lanzaboote",
+          "rust-overlay"
+        ],
         "tinted-schemes": "tinted-schemes_2",
         "vogix16-themes": "vogix16-themes"
       },
       "locked": {
-        "lastModified": 1781291835,
-        "narHash": "sha256-nFGYeGJPDoWsFRnb3HN3rYIrqw1VjPjdFdDj2SYuLRo=",
-        "ref": "refs/heads/wip/praxis-0.19-input-engine",
-        "rev": "91d7d9ad58b63b65bab28619b705a764874bb0a9",
-        "revCount": 141,
-        "type": "git",
-        "url": "file:///home/logger/Code/github/logger/vogix"
+        "lastModified": 1781721001,
+        "narHash": "sha256-ElDHGis+5nYaZwtz5le+LFazOEtXGkSUnnLEVeh4B2Q=",
+        "owner": "i-am-logger",
+        "repo": "vogix",
+        "rev": "5f04ff6d6dbc6e46567fd94fddbb45f18b496393",
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "file:///home/logger/Code/github/logger/vogix"
+        "owner": "i-am-logger",
+        "repo": "vogix",
+        "type": "github"
       }
     },
     "vogix16-themes": {
       "flake": false,
       "locked": {
-        "lastModified": 1775536832,
-        "narHash": "sha256-j4x1JuSnqfaEcu85bbaZoC6yriylSvsyFdq/OMqYbjo=",
+        "lastModified": 1781644806,
+        "narHash": "sha256-yRoklx45rknOyu3A9DhtqEex1ZL+pjg0ZbHytUb8k+4=",
         "owner": "i-am-logger",
         "repo": "vogix16-themes",
-        "rev": "a3a4671c5b7b9e877cdd5e384281651d9a17eb6e",
+        "rev": "ca0ad769211b2c5cac974b15fd52128c163f1b0a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,9 @@
     # mynixos - Typed functional DSL providing all dependencies
     mynixos = {
       url = "git+file:///home/logger/Code/github/logger/mynixos";
-      inputs.vogix.url = "git+file:///home/logger/Code/github/logger/vogix";
+      # vogix now flows from the released v0.7.0 (via mynixos) — the wip-branch
+      # override is retired since that work landed. vogix16-themes v0.2.0 comes
+      # through mynixos's direct themes override.
     };
     # Personal secrets (not managed by mynixos)
     secrets = {

--- a/systems/yoga/default.nix
+++ b/systems/yoga/default.nix
@@ -92,6 +92,11 @@ mynixos.lib.mkSystem {
     security = {
       enable = true;
       secureBoot.enable = true;
+      # No TPM-bound FDE here, so suppress systemd's SRK/NvPCR (measured-boot)
+      # setup and sweep the stale nvpcr-anchor creds it leaves on the ESP — those
+      # are what PID1 reports as "untrusted credentials" each boot. Flip to true
+      # if this box ever adopts TPM-sealed disk unlock.
+      tpm.enable = false;
       yubikey.enable = true;
       auditRules.enable = true;
       nopasswdRebuild = true;
@@ -284,5 +289,12 @@ mynixos.lib.mkSystem {
         ];
       }
     )
+
+    # DDR5 modules on this build carry addressable RGB (ENE controllers). DRAM RGB
+    # is its own hardware -- it travels with the sticks, independent of the board
+    # and the keyboard -- and is driven by OpenRGB, which lives in vogix. So flip
+    # vogix's dram-rgb hardware module on directly (it pulls in OpenRGB + the
+    # chipset SMBus stack on its own).
+    { vogix.hardware.dram-rgb.enable = true; }
   ];
 }


### PR DESCRIPTION
Downstream end of the vogix → mynixos → /etc/nixos cascade.

- **relock mynixos → `a725803` (0.11.1)** — pulls in **vogix v0.8.0** (variant-nav ramp-stepping + illumination-preserving theme switches, plus the docs↔code audit fixes) and the nixpkgs-deprecation fixes (`boot.bootspec.enable` removal, `libsForQt5.qt5.*`→`qt5.*`).
- **retire the wip-branch vogix override** — vogix now flows from the release via mynixos.
- **yoga**: `tpm.enable = false` (suppress the unused NvPCR measured-boot creds) and `vogix.hardware.dram-rgb.enable = true` (DDR5 ENE RGB via OpenRGB).

`nix eval` of `nixosConfigurations.yoga` is clean → `mynixos-system-yoga-0.11.1.drv`. Ready for `rebuild-system` switch after merge.