### PR TITLE
feat(deps): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Check Nix version
         run: nix --version
@@ -38,7 +38,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Validate flake structure
         run: |
@@ -62,7 +62,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Run flake check (dry-run)
         run: |
@@ -85,7 +85,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Build ${{ matrix.system }} configuration
         run: |
@@ -104,7 +104,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Evaluate yoga configuration
         run: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,7 +21,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Install system dependencies
         run: |
@@ -30,7 +30,7 @@ jobs:
           sudo update-ca-certificates || true
 
       - name: Setup Node.js for MCP servers
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -16,10 +16,10 @@ jobs:
       changed: ${{ steps.filter.outputs.installer }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Check for installer-related changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -36,7 +36,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Setup Nix
         uses: ./.github/actions/setup-nix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
@@ -35,7 +35,7 @@ jobs:
           docker load < result
       
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -66,10 +66,10 @@ jobs:
       changed: ${{ steps.filter.outputs.installer }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Check for installer-related changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -89,7 +89,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
@@ -104,7 +104,7 @@ jobs:
         run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       
       - name: Upload installer as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: installer-iso-sha-${{ steps.sha.outputs.short }}
           path: result/iso/*.iso
@@ -121,14 +121,14 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
       
       - name: Run Release Please
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: System information
         run: |


### PR DESCRIPTION
Bumps GitHub Actions to their latest releases (CI-config only; does not touch the system build).

| action | old → new |
|---|---|
| actions/checkout | v4 → v7 |
| actions/setup-node | v4 → v6 |
| actions/upload-artifact | v4 → v7 |
| dorny/paths-filter | v3 → v4 |
| docker/login-action | v3 → v4 |
| googleapis/release-please-action | v4 → v5 |

release-please-action v5 = node24 runtime only. `actionlint` is clean on the bumped `uses:` lines; its remaining findings (`runns-on:` typo, self-hosted runner-label allowlist, SC2086) are pre-existing and untouched here.